### PR TITLE
Fixing bug to not show progress

### DIFF
--- a/es_pandas/es_pandas.py
+++ b/es_pandas/es_pandas.py
@@ -223,5 +223,5 @@ class es_pandas(object):
 
 
 class BarNothing(object):
-    def update(self, arg):
+    def update(self, *arg):
         pass


### PR DESCRIPTION
Allowing `show_progress=False` for `update` method in `BarNothing` dummy class to allow no positional arguments. 